### PR TITLE
Add generic notification dialog and use it for config import errors

### DIFF
--- a/src/openvpn3_indicator/application.py
+++ b/src/openvpn3_indicator/application.py
@@ -786,7 +786,7 @@ class Application(Gtk.Application):
                     msg = excp.get_dbus_message()
                     msg = re.sub(r'^.*GDBus.Error:[^\s]*', '', msg).strip()
                     self.error(
-                        msg=f"OpenVPN Config {name} imported from {path} failed validation",
+                        msg=f"OpenVPN Config {name} imported from {path} failed validation: {msg}",
                         notify=False,
                         dialog=True,
                         title="Configuration Import Failed"

--- a/src/openvpn3_indicator/application.py
+++ b/src/openvpn3_indicator/application.py
@@ -50,6 +50,7 @@ from openvpn3_indicator.dialogs.about import construct_about_dialog
 from openvpn3_indicator.dialogs.system_checks import construct_appindicator_missing_dialog, construct_openvpn_missing_dialog
 from openvpn3_indicator.dialogs.credentials import CredentialsUserInput, construct_credentials_dialog
 from openvpn3_indicator.dialogs.configuration import construct_configuration_select_dialog, construct_configuration_import_dialog, construct_configuration_remove_dialog
+from openvpn3_indicator.dialogs.notification import show_error_dialog
 
 try:
     import openvpn3
@@ -784,13 +785,19 @@ class Application(Gtk.Application):
                 except dbus.exceptions.DBusException as excp:
                     msg = excp.get_dbus_message()
                     msg = re.sub(r'^.*GDBus.Error:[^\s]*', '', msg).strip()
-                    self.error(f'OpenVPN Config {name} imported from {path} failed validation: {msg}', notify=True)
+                    show_error_dialog(
+                        title="Configuration Import Failed",
+                        message=f"OpenVPN Config {name} imported from {path} failed validation",
+                    )
                     logging.info(f'Removing Config {name}')
                     config_obj.Remove()
             self.invalid_sessions = True
         except: #TODO: Catch only expected exceptions
             logging.debug(traceback.format_exc())
-            self.error(f'Failed to import configuration {name} from {path}', notify=True)
+            show_error_dialog(
+                title="Configuration Import Failed",
+                message=f"Failed to import configuration {name} from {path}",
+            )
 
     def action_config_import(self, _object):
         logging.info(f'Import Config')

--- a/src/openvpn3_indicator/dialogs/notification.py
+++ b/src/openvpn3_indicator/dialogs/notification.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# vim:ts=4:sts=4:sw=4:expandtab
+
+#
+# openvpn3-indicator - Simple indicator application for OpenVPN3.
+# Copyright (C) 2024 Grzegorz Gutowski <grzegorz.gutowski@uj.edu.pl>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+#
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import GLib, Gtk
+
+from openvpn3_indicator.about import APPLICATION_NAME
+
+def construct_notification_dialog(parent=None, title=None, message=None, message_type=Gtk.MessageType.INFO):
+    dialog = Gtk.MessageDialog(
+        parent=parent,
+        flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+        type=message_type,
+        buttons=Gtk.ButtonsType.OK
+    )
+
+    if title:
+        dialog.set_title(title)
+    else:
+        type_names = {
+            Gtk.MessageType.INFO: "Info",
+            Gtk.MessageType.WARNING: "Warning", 
+            Gtk.MessageType.ERROR: "Error",
+            Gtk.MessageType.QUESTION: "Question"
+        }
+        type_name = type_names.get(message_type, "Notification")
+        dialog.set_title(f"{APPLICATION_NAME} - {type_name}")
+
+    if message:
+        dialog.set_markup(GLib.markup_escape_text(message))
+
+    return dialog
+
+
+def show_notification_dialog(parent=None, title=None, message=None, message_type=Gtk.MessageType.INFO):
+    dialog = construct_notification_dialog(parent, title, message, message_type)
+    response = dialog.run()
+    dialog.destroy()
+    return response
+
+
+def show_info_notification(parent=None, title=None, message=None):
+    return show_notification_dialog(parent, title, message, Gtk.MessageType.INFO)
+
+
+def show_warning_notification(parent=None, title=None, message=None):
+    return show_notification_dialog(parent, title, message, Gtk.MessageType.WARNING)
+
+
+def show_error_notification(parent=None, title=None, message=None):
+    return show_notification_dialog(parent, title, message, Gtk.MessageType.ERROR)
+
+
+def show_question_notification(parent=None, title=None, message=None):
+    dialog = Gtk.MessageDialog(
+        parent=parent,
+        flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+        type=Gtk.MessageType.QUESTION,
+        buttons=Gtk.ButtonsType.YES_NO
+    )
+
+    if title:
+        dialog.set_title(title)
+    else:
+        dialog.set_title(f"{APPLICATION_NAME} - Question")
+
+    if message:
+        dialog.set_markup(GLib.markup_escape_text(message))
+
+    response = dialog.run()
+    dialog.destroy()
+    return response
+
+
+def construct_error_dialog(parent=None, title=None, message=None):
+    return construct_notification_dialog(parent, title, message, Gtk.MessageType.ERROR)
+
+
+def show_error_dialog(parent=None, title=None, message=None):
+    return show_error_notification(parent, title, message)

--- a/src/openvpn3_indicator/tests/notification.py
+++ b/src/openvpn3_indicator/tests/notification.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# vim:ts=4:sts=4:sw=4:expandtab
+
+import logging
+import sys
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import GLib, Gtk
+
+from openvpn3_indicator.about import APPLICATION_ID
+from openvpn3_indicator.dialogs.notification import (
+    show_info_notification,
+    show_warning_notification,
+    show_error_notification,
+    show_question_notification,
+    construct_notification_dialog
+)
+
+class Test(Gtk.Application):
+    def __init__(self):
+        Gtk.Application.__init__(self,
+            application_id=APPLICATION_ID,
+            )
+        self.connect('startup', self.on_startup)
+        self.connect('activate', self.on_activate)
+        self.test_step = 0
+
+    def on_activate(self, *args, **kwargs):
+        pass
+
+    def on_startup(self, *args, **kwargs):
+        self.hold()
+        self.run_next_test()
+
+    def run_next_test(self):
+        if self.test_step == 0:
+            print("Testing INFO notification...")
+            show_info_notification(
+                title="Test Info",
+                message="This is an info notification test"
+            )
+        elif self.test_step == 1:
+            print("Testing WARNING notification...")
+            show_warning_notification(
+                title="Test Warning",
+                message="This is a warning notification test"
+            )
+        elif self.test_step == 2:
+            print("Testing ERROR notification...")
+            show_error_notification(
+                title="Test Error",
+                message="This is an error notification test"
+            )
+        elif self.test_step == 3:
+            print("Testing QUESTION notification...")
+            response = show_question_notification(
+                title="Test Question",
+                message="This is a question notification test. Do you want to continue?"
+            )
+            print(f"Question response: {response}")
+        elif self.test_step == 4:
+            print("Testing construct_notification_dialog...")
+            dialog = construct_notification_dialog(
+                title="Test Custom Dialog",
+                message="This is a custom notification dialog test",
+                message_type=Gtk.MessageType.INFO
+            )
+            dialog.connect('response', self.on_dialog_response)
+            dialog.show()
+            return
+        else:
+            print("All tests completed!")
+            self.action_quit()
+            return
+
+        self.test_step += 1
+        GLib.timeout_add(500, self.run_next_test)
+
+    def on_dialog_response(self, dialog, response_id):
+        print(f"Custom dialog response: {response_id}")
+        dialog.destroy()
+        self.test_step += 1
+        GLib.timeout_add(500, self.run_next_test)
+
+    def action_quit(self, *args, **kwargs):
+        print("Test completed successfully!")
+        self.release()
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    print("Starting notification dialog tests...")
+    print("Each dialog will appear sequentially. Click OK to proceed to the next test.")
+    test = Test()
+    test.run(sys.argv)


### PR DESCRIPTION
A generic dialog called **notification** was created, which can be used for different types of notifications (**Warning, Info, Error, Question**). The goal is to allow messages to be displayed to the user even when **"Do Not Disturb"** mode is enabled (which silences regular notifications).  

In the `notification.py` file, lines 1 to 21 replicate the header already used by Grzegorz Gutowski in other dialogs.  
In the `on_config_import` function of the `application` module, I replaced the use of `self.error` with the new error dialog defined in `notification.py`. For now, this change was applied only in that function, but the idea is to expand its usage if approved.  

Currently, the default **GTK** dialog is being used to display warning messages.  
Below is a screenshot showing how the dialog is rendered to the user.  

<img width="650" height="164" alt="image" src="https://github.com/user-attachments/assets/c5a6ef19-1738-4188-a820-3902ee67caeb" />
